### PR TITLE
sda3 --> sda2 ?

### DIFF
--- a/BTRFS_on_LUKS_dev
+++ b/BTRFS_on_LUKS_dev
@@ -146,7 +146,7 @@ pacman -S intel-ucode grub efibootmgr
 # Configure GRUB to recognize the LUKS encrypted boot partition and unlock
 # the root LVM one at boot.
 --> /etc/default/grub
-    GRUB_CMDLINE_LINUX="... cryptdevice=UUID=</dev/sda3 UUID>:cryptbtrfs ..."
+    GRUB_CMDLINE_LINUX="... cryptdevice=UUID=</dev/sda2 UUID>:cryptbtrfs ..."
     GRUB_ENABLE_CRYPTODISK=y
 
 # Install GRUB to the mounted ESP then generate a config file for it


### PR DESCRIPTION
Hi Eugenio,
Thanks for the email yesterday - don't worry about the delay. Agree that Arch rocks although I'm a bit impatient to get good enough so I can start adding a bit of value like yourself and your guides. 
On those guides - for the one above, should you change line 149 to list sda2 as crypt device rather than sda3? (since we haven't created a partition sda3)
cryptdevice=UUID=</dev/sda3 UUID>
Should say though when i tried this, the final install just hangs on 'Scanning for BTRFS file systems'. So stuck either way!

Thanks and regards,

Simon